### PR TITLE
Fix pyxis

### DIFF
--- a/docker/postinstall.sh
+++ b/docker/postinstall.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-set -e
 
+set -exo pipefail
+
+echo "
+###################################
+# BEGIN: post-install docker
+###################################
+"
 
 OS=$(. /etc/os-release; echo $NAME)
 
@@ -36,3 +42,8 @@ else
         echo "Unsupported OS: ${OS}" && exit 1;
 fi
 
+echo "
+###################################
+# END: post-install docker
+###################################
+"

--- a/multi-runner/postinstall.sh
+++ b/multi-runner/postinstall.sh
@@ -47,7 +47,7 @@ def main():
 
         os.chmod(tmp.name, 0o777)
         tmp.file.close()
-        subprocess.run([tmp.name, *args], check=True, env=sub_env)
+        subprocess.run([tmp.name, *args], stderr=subprocess.STDOUT, check=True, env=sub_env)
 
 
 if __name__ == "__main__":

--- a/multi-runner/postinstall.sh
+++ b/multi-runner/postinstall.sh
@@ -47,6 +47,7 @@ def main():
 
         os.chmod(tmp.name, 0o777)
         tmp.file.close()
+        # Redirect stderr -> stdout, otherwise doesn't appear on cfn-init (file & cloudwatch)
         subprocess.run([tmp.name, *args], stderr=subprocess.STDOUT, check=True, env=sub_env)
 
 

--- a/pyxis/postinstall.sh
+++ b/pyxis/postinstall.sh
@@ -88,7 +88,7 @@ elif [ "${OS}" == "Ubuntu" ]; then
 	    	&& apt-get update -y \
 	    	&& apt-get install libnvidia-container-tools -y
 	fi
-	apt-get install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd
+	apt-get install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd libpmix-dev
 	if [[ $STABLE == 1 ]]; then
 		export arch=$(dpkg --print-architecture)
 		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_RELEASE}-1_${arch}.deb

--- a/pyxis/postinstall.sh
+++ b/pyxis/postinstall.sh
@@ -23,8 +23,9 @@ echo "
 ###################################
 "
 
-# Temporarily hardcoded.
 STABLE=0
+ENROOT_RELEASE=3.4.1	# For STABLE=1
+
 
 ########
 #ENROOT
@@ -52,8 +53,8 @@ if [ "${OS}" == "Amazon Linux" ]; then
 	yum install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd
 	[[ $STABLE == 1 ]] && {
 		export arch=$(uname -m)
-		yum install -y https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot-3.4.1-1.el8.${arch}.rpm
-		yum install -y https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot+caps-3.4.1-1.el8.${arch}.rpm
+		yum install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_RELEASE}/enroot-${ENROOT_RELEASE}-1.el8.${arch}.rpm
+		yum install -y https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_RELEASE}/enroot+caps-${ENROOT_RELEASE}-1.el8.${arch}.rpm
 	} || {
 		yum install -y git gcc make libcap libtool automake libmd-devel
 		pushd /opt
@@ -77,8 +78,8 @@ elif [ "${OS}" == "Ubuntu" ]; then
 	apt-get install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd
 	[[ $STABLE == 1 ]] && {
 		export arch=$(dpkg --print-architecture)
-		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot_3.4.1-1_${arch}.deb
-		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v3.4.1/enroot+caps_3.4.1-1_${arch}.deb # optional
+		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_RELEASE}-1_${arch}.deb
+		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_RELEASE}-1_${arch}.deb # optional
 		apt install -y ./*.deb
 	} || {
 		apt install -y git gcc make libcap2-bin libtool automake libmd-dev


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* squash utils not installed when OS repo does not provide slurm-devel. Happened on AMI derived from DLAMI Ubuntu 22.04. Also, PCluster has installed the dev headers on /opt/slurm.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
