### PR TITLE
Support containerized mpirun

### DIFF
--- a/pyxis/postinstall.sh
+++ b/pyxis/postinstall.sh
@@ -132,7 +132,7 @@ chmod 1777 ${SHARED_DIR}/enroot
 ########
 #PYXIS
 ########
-git clone --depth 1 --branch v0.18.0 https://github.com/NVIDIA/pyxis.git /tmp/pyxis
+git clone --depth 1 --branch v0.15.0 https://github.com/NVIDIA/pyxis.git /tmp/pyxis
 cd /tmp/pyxis
 CPPFLAGS='-I /opt/slurm/include/' make
 CPPFLAGS='-I /opt/slurm/include/' make install

--- a/pyxis/postinstall.sh
+++ b/pyxis/postinstall.sh
@@ -88,11 +88,11 @@ elif [ "${OS}" == "Ubuntu" ]; then
 	    	&& apt-get update -y \
 	    	&& apt-get install libnvidia-container-tools -y
 	fi
-	apt-get install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd libpmix-dev
+	apt-get install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd
 	if [[ $STABLE == 1 ]]; then
 		export arch=$(dpkg --print-architecture)
-		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot_${ENROOT_RELEASE}-1_${arch}.deb
-		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_VERSION}/enroot+caps_${ENROOT_RELEASE}-1_${arch}.deb # optional
+		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_RELEASE}/enroot_${ENROOT_RELEASE}-1_${arch}.deb
+		curl -fSsL -O https://github.com/NVIDIA/enroot/releases/download/v${ENROOT_RELEASE}/enroot+caps_${ENROOT_RELEASE}-1_${arch}.deb # optional
 		apt install -y ./*.deb
 	else
 		apt install -y git gcc make libcap2-bin libtool automake libmd-dev
@@ -102,6 +102,12 @@ elif [ "${OS}" == "Ubuntu" ]; then
 		prefix=/usr sysconfdir=/etc make setcap
 		popd
 	fi
+	ln -s /usr/share/enroot/hooks.d/50-slurm-pmi.sh /etc/enroot/hooks.d/
+	ln -s /usr/share/enroot/hooks.d/50-slurm-pytorch.sh /etc/enroot/hooks.d/
+
+	# https://github.com/NVIDIA/enroot/issues/136#issuecomment-1241257854
+	mkdir -p /etc/sysconfig
+	echo "PATH=/opt/slurm/sbin:/opt/slurm/bin:$(bash -c 'source /etc/environment ; echo $PATH')" >> /etc/sysconfig/slurmd
   	export NONROOT_USER=ubuntu
 else
 	echo "Unsupported OS: ${OS}" && exit 1;

--- a/pyxis/postinstall.sh
+++ b/pyxis/postinstall.sh
@@ -132,7 +132,7 @@ chmod 1777 ${SHARED_DIR}/enroot
 ########
 #PYXIS
 ########
-git clone --depth 1 --branch v0.15.0 https://github.com/NVIDIA/pyxis.git /tmp/pyxis
+git clone --depth 1 --branch v0.18.0 https://github.com/NVIDIA/pyxis.git /tmp/pyxis
 cd /tmp/pyxis
 CPPFLAGS='-I /opt/slurm/include/' make
 CPPFLAGS='-I /opt/slurm/include/' make install


### PR DESCRIPTION
*Issue #, if available:* #11 

*Description of changes:*
- enable containerized mpirun via `srun --mpi=pmix --container-image haha.sqsh <CMD>`
- minor changes: enable the pytorch hook which sets torchrun's env vars (https://github.com/NVIDIA/enroot/blob/master/conf/hooks/extra/50-slurm-pytorch.sh)
- bug fixes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
