### PR TITLE
Use target branch clone instead of shallow clone

### DIFF
--- a/nccl/postinstall.sh
+++ b/nccl/postinstall.sh
@@ -7,8 +7,7 @@ AWS_OFI_NCCL_VERSION=${2:-v1.9.1-aws}
 
 # Install NCCL
 if [ ! -d "/opt/nccl" ]; then
-  git clone --depth=1 https://github.com/NVIDIA/nccl.git /opt/nccl  && cd $_
-  git checkout ${NCCL_VERSION}
+  git clone  --single-branch --branch ${NCCL_VERSION} https://github.com/NVIDIA/nccl.git /opt/nccl
   cd /opt/nccl
   # Explicitly specify platforms since building for all takes ~10 minutes
   # It takes 6 min 7 sec for 70,80,90


### PR DESCRIPTION
Thank you Daisuke for reporting!

Since shallow clone does not include historical commits, one cannot checkout to target branch. This PR suggest to use

```
git clone  --single-branch --branch v2.21.5-1 https://github.com/NVIDIA/nccl.git
```
instead.

```
mlkeita on  main [✘+?]
➜ git clone --depth=1 https://github.com/NVIDIA/nccl.git
Cloning into 'nccl'...
remote: Enumerating objects: 216, done.
remote: Counting objects: 100% (216/216), done.
remote: Compressing objects: 100% (193/193), done.
remote: Total 216 (delta 26), reused 90 (delta 16), pack-reused 0
Receiving objects: 100% (216/216), 496.14 KiB | 7.09 MiB/s, done.
Resolving deltas: 100% (26/26), done.

nccl …
➜ ls
LICENSE.txt Makefile    README.md   ext-net     ext-tuner   makefiles   pkg         src

nccl on  master
➜ git checkout v2.21.5-1
error: pathspec 'v2.21.5-1' did not match any file(s) known to git
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
