### PR TITLE
Adding a guard for checking if slurmdbd.conf file exists or not

### DIFF
--- a/rest-api/slurm_rest_api.rb
+++ b/rest-api/slurm_rest_api.rb
@@ -45,7 +45,9 @@ ruby_block 'Add JWT configuration to slurmdbd.conf' do
     file.write_file
   end
   not_if "grep -q auth/jwt #{slurm_etc}/slurmdbd.conf"
+  only_if { ::File.exist? ("#{slurm_etc}/slurmdbd.conf")}
 end
+
 
 service 'slurmctld' do
   action :restart


### PR DESCRIPTION
*Issue #, if available:*
The file `/opt/slurm/etc/slurmdbd.conf` does not exist in cluster if we do not have `Scheduling/SlurmSettings/Database` in cluster config.

Adding guard to check for file existence.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
