### PR TITLE
Install fuse-overlayfs via yum instead

### DIFF
--- a/pyxis/postinstall.sh
+++ b/pyxis/postinstall.sh
@@ -54,14 +54,10 @@ if [ "${OS}" == "Amazon Linux" ]; then
 		&& yum install libnvidia-container-tools -y
 	fi
 
-	# alinux2 doesn't have fuse-overlayfs in its repos. So, the question is: which "alinux" this
-	# script was originall written for, to assume that it provides fuse-overlayfs?
+	# fuse-overlayfs is now available from the Extra Packages for Enterprise Linux repo via yum
+ 	amazon-linux-extras install epel
+	yum install -y epel-release	
 	yum install -y jq squashfs-tools parallel fuse-overlayfs pigz squashfuse zstd
-	if [[ ! -e /usr/bin/fuse-overlays ]]; then
-		wget $FUSE_OVERLAYFS_URL
-		yum localinstall -y $FUSE_OVERLAYFS_RPM
-		rm $FUSE_OVERLAYFS_RPM
-	fi
 
 	if [[ $STABLE == 1 ]]; then
 		export arch=$(uname -m)

--- a/pyxis/postinstall.sh
+++ b/pyxis/postinstall.sh
@@ -43,8 +43,6 @@ else
 fi
 
 if [ "${OS}" == "Amazon Linux" ]; then
-	FUSE_OVERLAYFS_URL=http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse-overlayfs-0.7.2-6.el7_8.x86_64.rpm
-	FUSE_OVERLAYFS_RPM=${FUSE_OVERLAYFS_URL##*/}   # fuse-overlayfs-xxx.rpm
 
 	if [ $GPU_PRESENT -eq 0 ] && [ $GPU_CONTAINER_PRESENT -gt 0 ]; then
 		distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-parallelcluster-post-install-scripts/issues/28

*Description of changes:*
Instead of installing fuse-overlayfs via wget from centos7 (http://mirror.centos.org/centos/7/extras/x86_64/Packages/fuse-overlayfs-0.7.2-6.el7_8.x86_64.rpm) which had an end of life June 30, 2024. We can install it via yum from the EPL repo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
