### PR TITLE
Fix slurmdbd issues

### DIFF
--- a/rest-api/slurm_rest_api.rb
+++ b/rest-api/slurm_rest_api.rb
@@ -48,8 +48,11 @@ ruby_block 'Add JWT configuration to slurmdbd.conf' do
   only_if { ::File.exist? ("#{slurm_etc}/slurmdbd.conf")}
 end
 
-
 service 'slurmctld' do
+  action :restart
+end
+
+service 'slurmdbd' do
   action :restart
 end
 


### PR DESCRIPTION
*Description of changes:*
- Restart `slurmdbd` after modifying config to ensure changes are applied. This should fix errors like `openapi_get_db_conn() failed to open slurmdb connection` when invoking the Slurm REST API.

*Testing:*
- Created a cluster with Slurm accounting configured and ran the `post-install.sh` script edited to run a custom version of `slurm_rest_api.rb`
- Successfully pinged the jobs endpoint with no errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
