### PR TITLE
Update postinstall.sh

### DIFF
--- a/nccl/postinstall.sh
+++ b/nccl/postinstall.sh
@@ -2,8 +2,8 @@
 
 set -exo pipefail
 
-NCCL_VERSION=${1:-v2.21.5-1}
-AWS_OFI_NCCL_VERSION=${2:-v1.9.1-aws}
+
+NCCL_VERSION=${1:-v2.26.2-1} #compatible with OFI-NCCL v 1.14.2 preinstalled on pcluster AMI https://github.com/aws/aws-ofi-nccl/releases/tag/v1.14.2
 
 # Install NCCL
 if [ ! -d "/opt/nccl" ]; then
@@ -22,16 +22,3 @@ if [ ! -d "/opt/nccl-tests" ]; then
   make -j $(nproc) MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME=/opt/nccl/build CUDA_HOME=/usr/local/cuda
 fi
 
-# Install AWS OFI NCCL
-if [ ! -d "/opt/aws-ofi-nccl" ]; then
-  git clone -b ${AWS_OFI_NCCL_VERSION} --depth=1 https://github.com/aws/aws-ofi-nccl.git /opt/aws-ofi-nccl
-  cd /opt/aws-ofi-nccl
-  ./autogen.sh
-  ./configure --enable-platform-aws \
-            --with-libfabric=/opt/amazon/efa \
-            --with-mpi=/opt/amazon/openmpi \
-            --with-cuda=/usr/local/cuda \
-            --prefix=/opt/aws-ofi-nccl
-  make -j $(nproc)
-  make install
-fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove OFI-NCCL installation as this is precompiled with EFA installer, update NCCL to latest compatible version of OFI-NCCL installed in pcluster AMI as of 09/03/2025 (https://github.com/aws/aws-ofi-nccl/releases/tag/v1.14.2)

```
$ dpkg -l | grep nccl
ii  libnccl-ofi:amd64                          1.14.2-1                                amd64        NCCL libfabric plugin
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
