### PR TITLE
Fix NCCL build for B200 (sm_100) and CUDA 13 compatibility

### DIFF
--- a/nccl/postinstall.sh
+++ b/nccl/postinstall.sh
@@ -10,9 +10,25 @@ if [ ! -d "/opt/nccl" ]; then
   git clone  --single-branch --branch ${NCCL_VERSION} https://github.com/NVIDIA/nccl.git /opt/nccl
   cd /opt/nccl
   # Explicitly specify platforms since building for all takes ~10 minutes.
-  # Covers V100 (sm_70), A100 (sm_80), H100 (sm_90), B200 (sm_100).
-  # The compute_100 PTX provides forward-compat for future Blackwell variants.
-  make -j src.build NVCC_GENCODE="-gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_100,code=compute_100"
+  # Pick GENCODE based on the available CUDA toolkit:
+  #   - CUDA >= 13 dropped sm_70 (V100); cover Ampere/Hopper/Blackwell.
+  #   - CUDA <  13 still supports sm_70; keep V100 in the matrix.
+  # In both cases, sm_100 (B200/Blackwell) is required to avoid
+  # 'Cuda failure: named symbol not found' on p6-b200 instances.
+  CUDA_MAJOR=$(/usr/local/cuda/bin/nvcc --version | grep -oP 'release \K[0-9]+' | head -1)
+  if [ "${CUDA_MAJOR:-0}" -ge 13 ]; then
+    NCCL_GENCODE="-gencode=arch=compute_80,code=sm_80 \
+                  -gencode=arch=compute_90,code=sm_90 \
+                  -gencode=arch=compute_100,code=sm_100 \
+                  -gencode=arch=compute_120,code=compute_120"
+  else
+    NCCL_GENCODE="-gencode=arch=compute_70,code=sm_70 \
+                  -gencode=arch=compute_80,code=sm_80 \
+                  -gencode=arch=compute_90,code=sm_90 \
+                  -gencode=arch=compute_100,code=sm_100 \
+                  -gencode=arch=compute_100,code=compute_100"
+  fi
+  make -j src.build NVCC_GENCODE="${NCCL_GENCODE}"
 fi
 
 # Install nccl-tests

--- a/nccl/postinstall.sh
+++ b/nccl/postinstall.sh
@@ -9,9 +9,10 @@ AWS_OFI_NCCL_VERSION=${2:-v1.9.1-aws}
 if [ ! -d "/opt/nccl" ]; then
   git clone  --single-branch --branch ${NCCL_VERSION} https://github.com/NVIDIA/nccl.git /opt/nccl
   cd /opt/nccl
-  # Explicitly specify platforms since building for all takes ~10 minutes
-  # It takes 6 min 7 sec for 70,80,90
-  make -j src.build NVCC_GENCODE="-gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_90,code=sm_90"
+  # Explicitly specify platforms since building for all takes ~10 minutes.
+  # Covers V100 (sm_70), A100 (sm_80), H100 (sm_90), B200 (sm_100).
+  # The compute_100 PTX provides forward-compat for future Blackwell variants.
+  make -j src.build NVCC_GENCODE="-gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_100,code=compute_100"
 fi
 
 # Install nccl-tests


### PR DESCRIPTION
## Problem
`NVCC_GENCODE` was hard-coded to `sm_70`/`sm_80`/`sm_90`, so `libnccl.so.2` had no cubins for Blackwell (B200, sm_100). 
Any NCCL operation on `p6-b200.48xlarge` failed with `Cuda failure: named symbol not found`. 
Additionally, CUDA 13 toolkits (ParallelCluster 3.15+ AMIs) reject `compute_70`, breaking the build entirely.

## Feature
This PR auto-selects a compatible arch matrix based on the detected CUDA major version:
- **CUDA ≥ 13**: `sm_80`/`sm_90`/`sm_100` + `compute_120` PTX
- **CUDA < 13**: `sm_70`/`sm_80`/`sm_90`/`sm_100` + `compute_100` PTX

The arch list is kept explicit to preserve the original ~6-8 min build-time bound.

## Tested
- End-to-end on a customer's 4-node `p6-b200.48xlarge` cluster (CUDA 12.8): `nccl-tests` runs with `busbw 380 GB/s @ 16 GB`, 0 errors.
- Build verified on ParallelCluster 3.15 AMI (CUDA 13.0) on `g5.4xlarge`: `libnccl.so.2` contains `sm_80`/`sm_90`/`sm_100` cubins.
